### PR TITLE
Enrich log events with truly structured caller information

### DIFF
--- a/Serilog.Enrichers.WithCallerTests/CallerEnricherTests.cs
+++ b/Serilog.Enrichers.WithCallerTests/CallerEnricherTests.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 
 using System.Diagnostics;
-
+using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Serilog.Core;
+using Serilog.Events;
 using Serilog.Sinks.InMemory;
 using Serilog.Sinks.InMemory.Assertions;
 
@@ -65,7 +66,7 @@ namespace Serilog.Enrichers.WithCaller.Tests
                 .HaveMessage("hello")
                 .Appearing().Once()
                 .WithProperty("Caller")
-                .WithValue($"Serilog.Enrichers.WithCaller.Tests.CallerEnricherTests.EnrichTestWithFileInfo() {fileName}:63");
+                .WithValue($"Serilog.Enrichers.WithCaller.Tests.CallerEnricherTests.EnrichTestWithFileInfo() {fileName}:64");
         }
 
         [TestMethod()]
@@ -83,6 +84,67 @@ namespace Serilog.Enrichers.WithCaller.Tests
                 .WithProperty("Caller")
                 .WithValue("Serilog.Enrichers.WithCaller.Tests.CallerEnricherTests.MaxDepthTest() at System.RuntimeMethodHandle.InvokeMethod(System.Object, System.Object[], System.Signature, System.Boolean, System.Boolean)");
             //"Serilog.Enrichers.WithCaller.Tests.CallerEnricherTests.MaxDepthTest()"
+        }
+
+        [TestMethod()]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void EnrichWithCallerInfoAsStructure(bool fileInfo)
+        {
+            var logger = CreateLogger(fileInfo);
+            logger.Information("hello");
+            var value = InMemoryInstance.Should()
+                .HaveMessage("hello")
+                .Appearing().Once()
+                .WithProperty("CallerInfo")
+                .Subject;
+
+            var caller = value.Should().BeOfType<StructureValue>().Subject;
+            caller.Properties.Should().ContainSingle(e => e.Name == "Class")
+                .Which.Value.Should().BeOfType<ScalarValue>()
+                .Which.Value.Should().Be("CallerEnricherTests");
+            caller.Properties.Should().ContainSingle(e => e.Name == "Namespace")
+                .Which.Value.Should().BeOfType<ScalarValue>()
+                .Which.Value.Should().Be("Serilog.Enrichers.WithCaller.Tests");
+            var method = caller.Properties.Should().ContainSingle(e => e.Name == "Method")
+                .Which.Value.Should().BeOfType<StructureValue>().Subject;
+            method.Properties.Should().ContainSingle(e => e.Name == "Name")
+                .Which.Value.Should().BeOfType<ScalarValue>()
+                .Which.Value.Should().BeOfType<string>()
+                .Which.Should().Be("EnrichWithCallerInfoAsStructure");
+            var parameter = method.Properties.Should().ContainSingle(e => e.Name == "Parameters")
+                .Which.Value.Should().BeOfType<SequenceValue>()
+                .Which.Elements.Should().ContainSingle()
+                .Which.Should().BeOfType<StructureValue>().Subject;
+            parameter.Properties.Should().HaveCount(2);
+            parameter.Properties.Should().Contain(e => e.Name == "Type")
+                .Which.Value.Should().BeOfType<ScalarValue>()
+                .Which.Value.Should().BeOfType<string>()
+                .Which.Should().Be("System.Boolean");
+            parameter.Properties.Should().Contain(e => e.Name == "Name")
+                .Which.Value.Should().BeOfType<ScalarValue>()
+                .Which.Value.Should().BeOfType<string>()
+                .Which.Should().Be("fileInfo");
+
+            if (fileInfo)
+            {
+                var file = caller.Properties.Should().ContainSingle(e => e.Name == "File")
+                    .Which.Value.Should().BeOfType<StructureValue>().Subject;
+                file.Properties.Should().ContainSingle(e => e.Name == "Path")
+                    .Which.Value.Should().BeOfType<ScalarValue>()
+                    .Which.Value.Should().BeOfType<string>()
+                    .Which.Should().EndWith("Serilog.Enrichers.WithCaller/Serilog.Enrichers.WithCallerTests/CallerEnricherTests.cs");
+                file.Properties.Should().ContainSingle(e => e.Name == "Line")
+                    .Which.Value.Should().BeOfType<ScalarValue>()
+                    .Which.Value.Should().Be(95);
+                file.Properties.Should().ContainSingle(e => e.Name == "Column")
+                    .Which.Value.Should().BeOfType<ScalarValue>()
+                    .Which.Value.Should().Be(13);
+            }
+            else
+            {
+                caller.Properties.Should().NotContain(e => e.Name == "File");
+            }
         }
     }
 }


### PR DESCRIPTION
Use a single `CallerInfo` structured property instead of multiple scalar Caller* properties.